### PR TITLE
Hotfix - Rename release method

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Make sure you have the Stripe credentials set in `config/services.php`
 ],
 ```
 
-> Keys can be found in your Stripe account https://dashboard.stripe.com/apikeys 
+> Keys can be found in your Stripe account https://dashboard.stripe.com/apikeys
 
 ## Configuration
 
@@ -142,7 +142,7 @@ Wherever you want the payment form to appear, add this component:
 ])
 ```
 
-The `returnUrl` is where we want Stripe to redirect us afer they have processed the payment on their servers. 
+The `returnUrl` is where we want Stripe to redirect us afer they have processed the payment on their servers.
 
 **Do NOT point this to the order confirmation page, as you'll see below**
 
@@ -159,8 +159,8 @@ if ($request->payment_intent) {
     $payment = \GetCandy\Facades\Payments::driver('card')->cart($cart)->withData([
         'payment_intent_client_secret' => $request->payment_intent_client_secret,
         'payment_intent' => $request->payment_intent,
-    ])->release();
-    
+    ])->authorize();
+
     if ($payment->success) {
         redirect()->route('checkout-success.view');
         return;
@@ -183,4 +183,3 @@ Contributions are welcome, if you are thinking of adding a feature, please submi
 ### Testing
 
 Currently we use a manual [MockClient](https://github.com/getcandy/stripe/blob/main/tests/Stripe/MockClient.php) to mock the responses the Stripe API will return. This is likely to be improved upon as tests are written, but it should be apparent what this is doing, so feel free to add your own responses.
-

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     }
   ],
   "require": {
+      "php": "^8.0",
       "getcandy/core": "^2.0-beta12",
       "stripe/stripe-php": "^7.114",
       "livewire/livewire": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-      "getcandy/core": "^2.0-beta11",
+      "getcandy/core": "^2.0-beta12",
       "stripe/stripe-php": "^7.114",
       "livewire/livewire": "^2.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,8 @@
       "livewire/livewire": "^2.0"
   },
   "require-dev": {
-      "mockery/mockery": "^1.4.4",
-      "nunomaduro/collision": "^5.10",
       "phpunit/phpunit": "^9.5.10",
+      "mockery/mockery": "^1.4.4",
       "orchestra/testbench": "^6.0|^7.0"
   },
   "autoload": {

--- a/src/StripePaymentType.php
+++ b/src/StripePaymentType.php
@@ -4,7 +4,7 @@ namespace GetCandy\Stripe;
 
 use GetCandy\Base\DataTransferObjects\PaymentCapture;
 use GetCandy\Base\DataTransferObjects\PaymentRefund;
-use GetCandy\Base\DataTransferObjects\PaymentRelease;
+use GetCandy\Base\DataTransferObjects\PaymentAuthorize;
 use GetCandy\Models\Transaction;
 use GetCandy\PaymentTypes\AbstractPayment;
 use GetCandy\Stripe\Facades\StripeFacade;
@@ -47,11 +47,11 @@ class StripePaymentType extends AbstractPayment
     }
 
     /**
-     * Release the payment for processing.
+     * Authorize the payment for processing.
      *
-     * @return \GetCandy\Base\DataTransferObjects\PaymentRelease
+     * @return \GetCandy\Base\DataTransferObjects\PaymentAuthorize
      */
-    public function release(): PaymentRelease
+    public function authorize(): PaymentAuthorize
     {
         if (!$this->order) {
             if (!$this->order = $this->cart->order) {
@@ -61,7 +61,7 @@ class StripePaymentType extends AbstractPayment
 
         if ($this->order->placed_at) {
             // Somethings gone wrong!
-            return new PaymentRelease(
+            return new PaymentAuthorize(
                 success: false,
                 message: 'This order has already been placed',
             );
@@ -93,7 +93,7 @@ class StripePaymentType extends AbstractPayment
 
 
         if (!in_array($this->paymentIntent->status, ['success', 'processing', 'requires_capture'])) {
-            return new PaymentRelease(
+            return new PaymentAuthorize(
                 success: false,
                 message: $this->paymentIntent->last_payment_error,
             );
@@ -245,6 +245,6 @@ class StripePaymentType extends AbstractPayment
             $this->order->transactions()->createMany($transactions);
         });
 
-        return new PaymentRelease(success: true);
+        return new PaymentAuthorize(success: true);
     }
 }

--- a/tests/Unit/StripePaymentTypeTest.php
+++ b/tests/Unit/StripePaymentTypeTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit;
 
-use GetCandy\Base\DataTransferObjects\PaymentRelease;
+use GetCandy\Base\DataTransferObjects\PaymentAuthorize;
 use GetCandy\Models\Transaction;
 use GetCandy\Stripe\Facades\StripeFacade;
 use GetCandy\Stripe\StripePaymentType;
@@ -25,9 +25,9 @@ class StripePaymentTypeTest extends TestCase
 
         $response = $payment->cart($cart)->withData([
             'payment_intent' => 'PI_CAPTURE',
-        ])->release();
+        ])->authorize();
 
-        $this->assertInstanceOf(PaymentRelease::class, $response);
+        $this->assertInstanceOf(PaymentAuthorize::class, $response);
         $this->assertTrue($response->success);
         $this->assertNotNull($cart->refresh()->order->placed_at);
 
@@ -50,9 +50,9 @@ class StripePaymentTypeTest extends TestCase
 
         $response = $payment->cart($cart)->withData([
             'payment_intent' => 'PI_FAIL',
-        ])->release();
+        ])->authorize();
 
-        $this->assertInstanceOf(PaymentRelease::class, $response);
+        $this->assertInstanceOf(PaymentAuthorize::class, $response);
         $this->assertFalse($response->success);
         $this->assertNull($cart->refresh()->order->placed_at);
 


### PR DESCRIPTION
Rename the `release` method to `authorize` for GetCandy beta12.